### PR TITLE
[fix] JSON 직렬화 에러 픽스

### DIFF
--- a/UOSense-Backend/src/main/java/UOSense/UOSense_Backend/dto/ReportResponse.java
+++ b/UOSense-Backend/src/main/java/UOSense/UOSense_Backend/dto/ReportResponse.java
@@ -1,28 +1,31 @@
 package UOSense.UOSense_Backend.dto;
 
 import UOSense.UOSense_Backend.entity.Report;
-import UOSense.UOSense_Backend.entity.Review;
-import UOSense.UOSense_Backend.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
+@Getter
 public class ReportResponse {
     private int id;
-    private Review review;
+    private int reviewId;
     private String title;
-    private User user;
+    private int userId;
     private String detail;
     private LocalDateTime createdAt;
 
     public static ReportResponse from(Report report) {
         return builder()
                 .id(report.getId())
-                .review(report.getReview())
+                .reviewId(report.getReview().getId())
                 .title(report.getTitle())
-                .user(report.getUser())
+                .userId(report.getUser().getId())
                 .detail(report.getDetail().getValue())
                 .createdAt(report.getCreatedAt())
                 .build();


### PR DESCRIPTION
발생 상황: Swagger를 통한 테스트 도중 Http 500 에러가 발생
이유: Report 엔티티의 Review 필드가 FetchType.LAZY로 설정되어 JSON 직렬화 과정에서 정보가 로드되지 않아 에러가 발생
해결책:
1. Review 필드의 FetchType을 EAGER로 변경 -> 로딩에 악영향을 줄 수 있어 후보에서 제외
2. Hibernate.initialize(Report.getReview())로 로딩을 먼저 함
-> Review 클래스 안에 Restaurant, User 필드도 존재해 추가적인 로딩이 필요해짐
-> 또한 Review 클래스 안에 Restaurant, User 같은 불필요하고 민감한 정보가 포함되어 Review 객체를 반환하는 것은 별로 좋지 않을 것 같다 생각
3. ReportResponse의 Review 필드 대신 ReviewResponse dto를 필드로 반환
-> 이러면 2번의 문제 모두 해결 가능해짐. 하지만 ReviewResponse의 필드 중 reviewImages 필드도 있어 리뷰 이미지를 가져오는 과정이 추가로 필요해짐 
-> 그래서 이럴 거면 reviewId를 반환하고 reviewId로 단일 ReviewReponse를 반환하는 API를 추가로 만드는게 깔끔해보임
4. (현재 PR) 그래서 reviewId를 필드로 설정한 상태. 여기서 동의하시면 추가적으로 단일 리뷰를 반환하는 API를 추가로 만들 예정

resolves issue/#57